### PR TITLE
Add option to preserve original split files in addition to concatenating

### DIFF
--- a/index.js
+++ b/index.js
@@ -205,6 +205,15 @@ module.exports = {
 
   wrapScriptsInFunction: true,
 
+ /**
+  Whether or not to original files regardless of concatenation.
+
+  @property preserveOriginals
+  @type Boolean
+  @default true
+  */
+
+  preserveOriginals: false,
   /**
   Append `<link>` and `<script>` tags to the app's HTML file to load only the assets we require.
 
@@ -378,10 +387,11 @@ module.exports = {
     var workingTree = mergeTrees([tree, concatenatedScripts, concatenatedStyles]);
 
     /* Remove the unnecessary files */
-
-    workingTree = fileRemover(workingTree, {
-      files: scriptInputFiles.concat(styleInputFiles)
-    });
+    if (!this.preserveOriginals) {
+      workingTree = fileRemover(workingTree, {
+        files: scriptInputFiles.concat(styleInputFiles)
+      });
+    }
 
     return workingTree;
   }


### PR DESCRIPTION
added ability to generate concatenated files and preserve split files as well.

use case is when using ember-cli-mocha there is no option to defer test execution.

When running tests in the browser (testing=false) the requisite test files are not inserted between vendor and app