### PR TITLE
ensure compatability with ember-sprite

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "before": "broccoli-asset-rev",
     "configPath": "tests/dummy/config",
     "after": [
-      "ember-component-css"
+      "ember-component-css",
+      "ember-sprite"
     ]
   }
 }


### PR DESCRIPTION
Without the after constraint css sprites generated using ember-sprite don't get included in the concatenated output fule