### PR TITLE
Add support for async script tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,8 @@ module.exports = {
     contentFor: 'concat-js',
     footer: null,
     header: null,
-    preserveOriginal: true
+    preserveOriginal: true,
+    useAsync: false
   },
 
   css: {
@@ -209,6 +210,9 @@ module.exports = {
     var closing;
 
     if (ext === 'js') {
+      if (this.js.useAsync) {
+        return '<script async src="' + path + '"></script>\n';
+      }
       return '<script src="' + path + '"></script>\n';
     } else {
       closing = this.useSelfClosingTags ? ' /' : '';


### PR DESCRIPTION
Hi, this adds a new `js.useAsync` option that sets `<script async ...>`. Should improve performance in most cases but by default it should not be enabled.

Let me know what you think.

https://github.com/sir-dunxalot/ember-cli-concat/issues/28