### PR TITLE
Replace with vendor path first if disabled.

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,7 +172,7 @@ module.exports = {
       } else {
         return undefined;
       }
-      return concat ? [this.outputAppPath(ext)] : [this.appPath(ext), this.vendorPath(ext)];
+      return concat ? [this.outputAppPath(ext)] : [this.vendorPath(ext), this.appPath(ext)];
     }
   },
 


### PR DESCRIPTION
If JS concatenation is not enabled, then the content-for markup is replaced with `app.js` declared first, and `vendor.js` second. Our app startup overrides an Ember Data adapter, which in this order does not work. This PR is simply to switch the order so that `vendor.js` is loaded first.