### PR TITLE
Convert "ember-cli-babel" to dev dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "4"
 
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "chai-fs": "git://github.com/sir-dunxalot/chai-fs.git#master",
     "ember-cli": "^2.4.0",
     "ember-cli-app-version": "^1.0.0",
+    "ember-cli-babel": "^5.1.6",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
@@ -52,8 +53,7 @@
   "dependencies": {
     "broccoli-file-remover": "^0.3.1",
     "broccoli-merge-trees": "^1.1.4",
-    "broccoli-concat": "^3.0.4",
-    "ember-cli-babel": "^5.1.6"
+    "broccoli-concat": "^3.0.4"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
This is not needed as a real dependency because we don't have an "addon" folder that needs to be transpiled.

/cc @rwwagner90 