### PR TITLE
Ensure CSS concat ordering

### DIFF
--- a/index.js
+++ b/index.js
@@ -296,7 +296,8 @@ module.exports = {
       /* Locate all style files and concatenate into one file */
 
       if (cssOptions.concat) {
-        styleInputPaths = [this.appPath('css', true), this.vendorPath('css', true)];
+        styleInputPaths = [this.appPath('css', true)];
+        var cssHeaderFiles = [this.vendorPath('css', true)];
 
         concatenatedStyles = concatAndMap(tree, {
           allowNone: true,
@@ -304,11 +305,12 @@ module.exports = {
           header: cssOptions.header,
           inputFiles: styleInputPaths,
           outputFile: outputPath + '.css',
+          headerFiles: cssHeaderFiles,
           wrapInFunction: false
         });
 
         if (!cssOptions.preserveOriginal) {
-          removeFromTree(styleInputPaths);
+          removeFromTree(styleInputPaths.concat(cssHeaderFiles));
         }
       }
 


### PR DESCRIPTION
The order should be `vendor.css, app.css`, but with the current code the order was indeterministic due to how `broccoli-concat` works.

This order also matches the order that Ember CLI has for the CSS links in the `index.html` (see https://github.com/ember-cli/ember-cli/blob/v2.17.0/blueprints/app/files/app/index.html#L12-L13)

/cc @rwwagner90 