### PR TITLE
Fix when using ember serve

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,7 +210,8 @@ module.exports = {
     var closing;
 
     if (ext === 'js') {
-      if (this.js.useAsync) {
+      // In development the vendor.js file can not use async.
+      if (this.js.useAsync && path !== '/assets/vendor.js') {
         return '<script async src="' + path + '"></script>\n';
       }
       return '<script src="' + path + '"></script>\n';


### PR DESCRIPTION
I noticed that if ember-cli-concat isn't sending the merged scripts in development mode. Which makes sense. But if you've enabled the `useAsync` option, Ember apps won't run boot. This is because the vendor.js can not be loaded async.

So I added an obvious (naive?) check to fix it.