### PR TITLE
Drop support for Node.js 4 and below

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "4"
+  - "6"
 
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "git://github.com/sir-dunxalot/ember-cli-concat.git"
   },
   "engines": {
-    "node": ">= 0.10.0"
+    "node": "6.* || 8.* || >= 10.*"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
This will allow us to upgrade several dependencies, which will then allow users to use this addon with Broccoli 2, which was released as part of Ember CLI 3.5.

/cc @rwwagner90 