### PR TITLE
Add support for defer script tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,14 +233,14 @@ module.exports = {
       const scriptAttributes = [];
 
       if (this.js.useAsync) {
-        scriptAttributes.push(' async');
+        scriptAttributes.push('async');
       }
 
       if (this.js.useDefer) {
-        scriptAttributes.push(' defer');
+        scriptAttributes.push('defer');
       }
   
-      return '<script' + scriptAttributes.join('') + ' src="' + path + '"></script>\n';
+      return '<script ' + scriptAttributes.join(' ') + ' src="' + path + '"></script>\n';
     } else {
       closing = this.useSelfClosingTags ? ' /' : '';
 

--- a/index.js
+++ b/index.js
@@ -40,7 +40,8 @@ module.exports = {
     footer: null,
     header: null,
     preserveOriginal: true,
-    useAsync: false
+    useAsync: false,
+    useDefer: false
   },
 
   css: {
@@ -229,10 +230,17 @@ module.exports = {
     }
 
     if (ext === 'js') {
+      const scriptAttributes = [];
+
       if (this.js.useAsync) {
-        return '<script async src="' + path + '"></script>\n';
+        scriptAttributes.push(' async');
       }
-      return '<script src="' + path + '"></script>\n';
+
+      if (this.js.useDefer) {
+        scriptAttributes.push(' defer');
+      }
+  
+      return '<script' + scriptAttributes.join('') + ' src="' + path + '"></script>\n';
     } else {
       closing = this.useSelfClosingTags ? ' /' : '';
 


### PR DESCRIPTION
Similar to the `async` script tag, this adds an option `js.useDefer` which adds `<script defer ...>`. When enabling both options, most browsers will prefer `async`, and fall back to `defer` when support is limited.