### PR TITLE
Add support for pre-loading css

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,8 @@ module.exports = {
     contentFor: 'concat-css',
     footer: null,
     header: null,
-    preserveOriginal: true
+    preserveOriginal: true,
+    preLoad: false,
   },
 
   /**
@@ -233,10 +234,11 @@ module.exports = {
         return '<script async src="' + path + '"></script>\n';
       }
       return '<script src="' + path + '"></script>\n';
-    } else {
+    } else if (ext === 'css') {
       closing = this.useSelfClosingTags ? ' /' : '';
-
-      return '<link rel="stylesheet" href="' + path + '"' + closing + '>\n';
+      if (this.css.preLoad) {
+        return '<link rel="preload" href="' + path + '"' + closing + ' as="style">\n<link rel="stylesheet" href="' + path + '"' + closing + '>\n';
+      }
     }
   },
 

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = {
     footer: null,
     header: null,
     preserveOriginal: true,
-    preLoad: false,
+    preLoad: false
   },
 
   /**
@@ -239,6 +239,7 @@ module.exports = {
       if (this.css.preLoad) {
         return '<link rel="preload" href="' + path + '"' + closing + ' as="style">\n<link rel="stylesheet" href="' + path + '"' + closing + '>\n';
       }
+      return '<link rel="stylesheet" href="' + path + '"' + closing + '>\n';
     }
   },
 

--- a/index.js
+++ b/index.js
@@ -249,12 +249,13 @@ module.exports = {
       return cleanTag('<script ' + scriptAttributes.join(' ') + ' src="' + path + '"></script>\n');
     } else if (ext === 'css') {
       closing = this.useSelfClosingTags ? ' /' : '';
+      let cssString = '<link rel="stylesheet" href="' + path + '"' + closing + '>\n';
 
       if (this.css.preLoad) {
-        return cleanTag('<link rel="preload" href="' + path + '"' + closing + ' as="style">\n<link rel="stylesheet" href="' + path + '"' + closing + '>\n');
+        cssString = '<link rel="preload" href="' + path + '"' + closing + ' as="style">\n' + cssString;
       }
 
-      return cleanTag('<link rel="stylesheet" href="' + path + '"' + closing + '>\n');
+      return cleanTag(cssString);
     }
   },
 


### PR DESCRIPTION
When enabled, this adds `<link rel="preload" href="/path/to/css" as="style">` ([browser support](https://caniuse.com/link-rel-preload)) for preloading css